### PR TITLE
Fix windows build platform

### DIFF
--- a/applications/server/project.json
+++ b/applications/server/project.json
@@ -33,7 +33,7 @@
 				"commands": [
 					"yarn nx release server --platform mac",
 					"yarn nx release server --platform linux",
-					"yarn nx release server --platform windows"
+					"yarn nx release server --platform win"
 				],
 				"parallel": false
 			}

--- a/packages/cs-parser/project.json
+++ b/packages/cs-parser/project.json
@@ -31,7 +31,7 @@
 				"commands": [
 					"yarn nx release parser --platform mac",
 					"yarn nx release parser --platform linux",
-					"yarn nx release parser --platform windows"
+					"yarn nx release parser --platform win"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
Fix release:all scripts in server and parser to build with platform "win" instead of incorrect "windows"