### PR TITLE
Bugfix/528 turning on show hidden beacons button causes search to crash

### DIFF
--- a/applications/client/src/components/Forms/SettingsForm.tsx
+++ b/applications/client/src/components/Forms/SettingsForm.tsx
@@ -52,6 +52,7 @@ export const SettingsForm = observer<SettingsFormProps>(({ ...props }) => {
 					store.settings.setShowHidden(e.target.checked);
 					store.reset(false);
 					store.campaign.refetch();
+					store.campaign.search.clearSearch();
 					store.router.updateRoute({
 						path: store.router.currentRoute,
 						params: {

--- a/applications/client/src/views/Campaign/Explore/Panels/Meta/use-toggle-hidden.ts
+++ b/applications/client/src/views/Campaign/Explore/Panels/Meta/use-toggle-hidden.ts
@@ -21,6 +21,7 @@ export function useToggleHidden(mutation: () => Promise<any>) {
 
 			store.reset(false);
 			store.campaign.refetch();
+			store.campaign.search.clearSearch();
 		},
 	});
 


### PR DESCRIPTION
Fix #14 