### PR TITLE
Fix executable sometimes not finding export worker script

### DIFF
--- a/applications/server/package.json
+++ b/applications/server/package.json
@@ -3,6 +3,9 @@
 	"version": "0.9.0",
 	"bin": "./src/index.js",
 	"pkg": {
+		"scripts": [
+			"./src/machines/anonymization/anonymization.worker.js"
+		],
 		"assets": [
 			"../client/**/*",
 			"../../../node_modules/better-sqlite3/**/*.*"

--- a/applications/server/src/machines/anonymization/anonymize.service.ts
+++ b/applications/server/src/machines/anonymization/anonymize.service.ts
@@ -4,8 +4,8 @@ import { AnonymizationMachineContext } from './anonymization.machine';
 
 export const anonymizeService = (context: AnonymizationMachineContext) =>
 	new Promise<never>((resolve, reject) => {
-		// TODO: Ensure this compiles correctly for prod
 		const worker = new Worker(path.join(__dirname, './anonymization.worker.js'), {
+			execArgv: [],
 			workerData: {
 				...context,
 				path: './anonymization.worker.ts',


### PR DESCRIPTION
Explicitly includes path to export worker script in pkg config