### PR TITLE
Quick metadata editing for Server/Host/Beacon

### DIFF
--- a/applications/client/src/views/Campaign/Explore/Panels/Beacon/Beacon.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Beacon/Beacon.tsx
@@ -3,12 +3,13 @@ import { dateShortFormat, semanticIcons } from '@redeye/client/components';
 import type { BeaconModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
 import { TimeStatus } from '@redeye/client/types/timeline';
-import { IconLabel, InfoRow, RowMuted, RowTime, RowTitle } from '@redeye/client/views';
+import { IconLabel, InfoRow, RowMuted, RowTime, RowTitle, useToggleHidden } from '@redeye/client/views';
 import { FlexSplitter } from '@redeye/ui-styles';
 import { observer } from 'mobx-react-lite';
 import type { ComponentProps } from 'react';
 import { useMemo } from 'react';
 import { MitreTechniqueIcons } from '../../components/MitreTechniqueIcons';
+import { QuickMeta } from '../QuickMeta';
 
 type BeaconProps = ComponentProps<'div'> & {
 	beacon: BeaconModel;
@@ -21,6 +22,13 @@ export const BeaconRow = observer<BeaconProps>(({ beacon, ...props }) => {
 		[beacon.displayName, beacon.server?.displayName]
 	);
 
+	const [, mutateToggleHidden] = useToggleHidden(
+		async () =>
+			await store.graphqlStore.mutateToggleBeaconHidden({
+				campaignId: store.campaign?.id!,
+				beaconId: beacon?.id!,
+			})
+	);
 	return (
 		<InfoRow
 			cy-test="info-row"
@@ -45,6 +53,7 @@ export const BeaconRow = observer<BeaconProps>(({ beacon, ...props }) => {
 				icon={semanticIcons.commands}
 				className={skeletonClass}
 			/>
+			<QuickMeta modal={beacon} mutateToggleHidden={mutateToggleHidden} />
 		</InfoRow>
 	);
 });

--- a/applications/client/src/views/Campaign/Explore/Panels/Beacon/Beacon.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Beacon/Beacon.tsx
@@ -1,4 +1,5 @@
 import { Classes } from '@blueprintjs/core';
+import { ViewOff16 } from '@carbon/icons-react';
 import { dateShortFormat, semanticIcons } from '@redeye/client/components';
 import type { BeaconModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
@@ -44,6 +45,7 @@ export const BeaconRow = observer<BeaconProps>(({ beacon, ...props }) => {
 			</RowTime>
 			<RowTitle className={skeletonClass}>{beacon?.displayName || `${beacon.server?.displayName}`}</RowTitle>
 			<RowMuted className={skeletonClass}>{beacon.meta?.[0]?.maybeCurrent?.username}</RowMuted>
+			{beacon?.hidden && <IconLabel title="Hidden" icon={ViewOff16} />}
 			<FlexSplitter />
 			<MitreTechniqueIcons mitreAttackIds={beacon.mitreTechniques} />
 			<IconLabel

--- a/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
@@ -1,3 +1,4 @@
+import { ViewOff16 } from '@carbon/icons-react';
 import { CarbonIcon, dateShortFormat, dateShortPlaceholder, semanticIcons } from '@redeye/client/components';
 import type { HostModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
@@ -47,6 +48,7 @@ export const HostRow = observer<HostRowProps>(({ host, ...props }) => {
 					{host.displayName}
 				</Txt>
 			</RowTitle>
+			{host?.hidden && <IconLabel title="Hidden" icon={ViewOff16} />}
 			<FlexSplitter />
 			{!host.cobaltStrikeServer && (
 				<>

--- a/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
@@ -1,9 +1,13 @@
+import { Menu, MenuItem, Position } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
+import { OverflowMenuVertical16, View16, ViewOff16 } from '@carbon/icons-react';
+import { css } from '@emotion/react';
 import { CarbonIcon, dateShortFormat, dateShortPlaceholder, semanticIcons } from '@redeye/client/components';
 import type { HostModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
 import { TimeStatus } from '@redeye/client/types';
-import { IconLabel, InfoRow, RowTime, RowTitle } from '@redeye/client/views';
-import { FlexSplitter, Txt } from '@redeye/ui-styles';
+import { IconLabel, InfoRow, RowTime, RowTitle, useToggleHidden } from '@redeye/client/views';
+import { CoreTokens, FlexSplitter, Txt } from '@redeye/ui-styles';
 import { observer } from 'mobx-react-lite';
 import type { ComponentProps } from 'react';
 
@@ -15,6 +19,12 @@ export const HostRow = observer<HostRowProps>(({ host, ...props }) => {
 	const store = useStore();
 
 	if (!host) return null;
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [toggleHidden, mutateToggleHidden] = useToggleHidden(
+		async () => await store.graphqlStore.mutateToggleHostHidden({ campaignId: store.campaign?.id!, hostId: host?.id! })
+	);
+
 	return (
 		<InfoRow
 			onClick={() => host.select()}
@@ -41,8 +51,47 @@ export const HostRow = observer<HostRowProps>(({ host, ...props }) => {
 				<>
 					<IconLabel cy-test="row-command-count" title="Commands" value={host.commandsCount} icon={semanticIcons.commands} />
 					<IconLabel cy-test="row-beacon-count" value={host.beaconCount} title="Beacons" icon={semanticIcons.beacon} />
+					<Popover2
+						position={Position.RIGHT}
+						openOnTargetFocus={false}
+						interactionKind="hover"
+						hoverOpenDelay={300}
+						modifiers={{
+							offset: {
+								enabled: true,
+								options: {
+									offset: [0, 30],
+								},
+							},
+						}}
+						content={
+							<Menu>
+								<MenuItem
+									text={`${host?.hidden ? 'Show' : 'Hide'} Host`}
+									icon={<CarbonIcon icon={host?.hidden ? View16 : ViewOff16} css={iconStyle(!!host?.hidden)} />}
+									onClick={(e) => {
+										e.stopPropagation();
+										mutateToggleHidden.mutate();
+									}}
+								/>
+							</Menu>
+						}
+					>
+						<CarbonIcon icon={OverflowMenuVertical16} css={[iconStyle(), hoverStyle]} />
+					</Popover2>
 				</>
 			)}
 		</InfoRow>
 	);
 });
+
+const iconStyle = (show?: boolean) => css`
+	margin: 0;
+	color: ${show ? CoreTokens.TextBody : CoreTokens.TextDisabled} !important;
+`;
+
+const hoverStyle = css`
+	:hover {
+		color: ${CoreTokens.TextBody} !important;
+	}
+`;

--- a/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Host/Host.tsx
@@ -1,15 +1,12 @@
-import { Menu, MenuItem, Position } from '@blueprintjs/core';
-import { Popover2 } from '@blueprintjs/popover2';
-import { OverflowMenuVertical16, View16, ViewOff16 } from '@carbon/icons-react';
-import { css } from '@emotion/react';
 import { CarbonIcon, dateShortFormat, dateShortPlaceholder, semanticIcons } from '@redeye/client/components';
 import type { HostModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
 import { TimeStatus } from '@redeye/client/types';
 import { IconLabel, InfoRow, RowTime, RowTitle, useToggleHidden } from '@redeye/client/views';
-import { CoreTokens, FlexSplitter, Txt } from '@redeye/ui-styles';
+import { FlexSplitter, Txt } from '@redeye/ui-styles';
 import { observer } from 'mobx-react-lite';
 import type { ComponentProps } from 'react';
+import { QuickMeta } from '../QuickMeta';
 
 type HostRowProps = ComponentProps<'div'> & {
 	host: HostModel;
@@ -20,9 +17,13 @@ export const HostRow = observer<HostRowProps>(({ host, ...props }) => {
 
 	if (!host) return null;
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [toggleHidden, mutateToggleHidden] = useToggleHidden(
-		async () => await store.graphqlStore.mutateToggleHostHidden({ campaignId: store.campaign?.id!, hostId: host?.id! })
+	const [, mutateToggleHidden] = useToggleHidden(async () =>
+		host.cobaltStrikeServer
+			? await store.graphqlStore.mutateToggleServerHidden({
+					campaignId: store.campaign?.id!,
+					serverId: host?.serverId!,
+			  })
+			: await store.graphqlStore.mutateToggleHostHidden({ campaignId: store.campaign?.id!, hostId: host?.id! })
 	);
 
 	return (
@@ -51,47 +52,9 @@ export const HostRow = observer<HostRowProps>(({ host, ...props }) => {
 				<>
 					<IconLabel cy-test="row-command-count" title="Commands" value={host.commandsCount} icon={semanticIcons.commands} />
 					<IconLabel cy-test="row-beacon-count" value={host.beaconCount} title="Beacons" icon={semanticIcons.beacon} />
-					<Popover2
-						position={Position.RIGHT}
-						openOnTargetFocus={false}
-						interactionKind="hover"
-						hoverOpenDelay={300}
-						modifiers={{
-							offset: {
-								enabled: true,
-								options: {
-									offset: [0, 30],
-								},
-							},
-						}}
-						content={
-							<Menu>
-								<MenuItem
-									text={`${host?.hidden ? 'Show' : 'Hide'} Host`}
-									icon={<CarbonIcon icon={host?.hidden ? View16 : ViewOff16} css={iconStyle(!!host?.hidden)} />}
-									onClick={(e) => {
-										e.stopPropagation();
-										mutateToggleHidden.mutate();
-									}}
-								/>
-							</Menu>
-						}
-					>
-						<CarbonIcon icon={OverflowMenuVertical16} css={[iconStyle(), hoverStyle]} />
-					</Popover2>
 				</>
 			)}
+			<QuickMeta modal={host} mutateToggleHidden={mutateToggleHidden} />
 		</InfoRow>
 	);
 });
-
-const iconStyle = (show?: boolean) => css`
-	margin: 0;
-	color: ${show ? CoreTokens.TextBody : CoreTokens.TextDisabled} !important;
-`;
-
-const hoverStyle = css`
-	:hover {
-		color: ${CoreTokens.TextBody} !important;
-	}
-`;

--- a/applications/client/src/views/Campaign/Explore/Panels/Meta/use-toggle-hidden.ts
+++ b/applications/client/src/views/Campaign/Explore/Panels/Meta/use-toggle-hidden.ts
@@ -15,7 +15,12 @@ export function useToggleHidden(mutation: () => Promise<any>) {
 				params: {
 					currentItem: 'all',
 					currentItemId: undefined,
-					tab: Tabs.HOSTS,
+					tab:
+						store.router.params.tab === Tabs.METADATA
+							? store.router.params.currentItem === 'beacon'
+								? Tabs.BEACONS
+								: Tabs.HOSTS
+							: store.router.params.tab || Tabs.HOSTS,
 				},
 			});
 

--- a/applications/client/src/views/Campaign/Explore/Panels/QuickMeta.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/QuickMeta.tsx
@@ -1,0 +1,68 @@
+import { Menu, MenuItem, Position } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
+import { OverflowMenuVertical16, View16, ViewOff16 } from '@carbon/icons-react';
+import { css } from '@emotion/react';
+import { CarbonIcon } from '@redeye/client/components';
+import { BeaconModel, HostModel } from '@redeye/client/store';
+import type { ServerModel } from '@redeye/client/store';
+import { CoreTokens } from '@redeye/ui-styles';
+import type { UseMutationResult } from '@tanstack/react-query';
+import { observer } from 'mobx-react-lite';
+import type { ComponentProps } from 'react';
+
+type HostRowProps = ComponentProps<'div'> & {
+	modal: HostModel | ServerModel | BeaconModel;
+	mutateToggleHidden: UseMutationResult<any, unknown, void, unknown>;
+};
+
+export const QuickMeta = observer<HostRowProps>(({ modal, mutateToggleHidden }) => {
+	if (!modal) return null;
+
+	return (
+		<Popover2
+			position={Position.RIGHT}
+			openOnTargetFocus={false}
+			interactionKind="hover"
+			hoverOpenDelay={300}
+			modifiers={{
+				offset: {
+					enabled: true,
+					options: {
+						offset: [0, 30],
+					},
+				},
+			}}
+			content={
+				<Menu>
+					<MenuItem
+						text={`${modal?.hidden ? 'Show ' : 'Hide '} ${
+							modal instanceof BeaconModel
+								? 'Beacon'
+								: modal instanceof HostModel && modal.cobaltStrikeServer
+								? 'Server'
+								: 'Host'
+						}`}
+						icon={<CarbonIcon icon={modal?.hidden ? View16 : ViewOff16} css={iconStyle(!!modal?.hidden)} />}
+						onClick={(e) => {
+							e.stopPropagation();
+							mutateToggleHidden.mutate();
+						}}
+					/>
+				</Menu>
+			}
+		>
+			<CarbonIcon icon={OverflowMenuVertical16} css={[iconStyle(), hoverStyle]} />
+		</Popover2>
+	);
+});
+
+const iconStyle = (show?: boolean) => css`
+	margin: 0;
+	color: ${show ? CoreTokens.TextBody : CoreTokens.TextDisabled} !important;
+`;
+
+const hoverStyle = css`
+	:hover {
+		color: ${CoreTokens.TextBody} !important;
+	}
+`;

--- a/applications/client/src/views/Campaign/Timeline/BarLabels.tsx
+++ b/applications/client/src/views/Campaign/Timeline/BarLabels.tsx
@@ -96,7 +96,7 @@ export const BarLabelBeaconList = observer<BarLabelsProps>(({ bar, dateFormatter
 						{store.graphqlStore.beacons.get(beaconCommand.beaconId as string)?.displayName}
 					</Txt>
 					<Txt muted small css={marginStyles(4)}>
-						{store.graphqlStore.beacons.get(beaconCommand.beaconId as string)?.meta[0].maybeCurrent?.username}
+						{store.graphqlStore.beacons.get(beaconCommand.beaconId as string)?.meta[0]?.maybeCurrent?.username}
 					</Txt>
 					<FlexSplitter />
 					<Txt small>{beaconCommand.commandCount}</Txt>

--- a/applications/client/src/views/Campaign/Timeline/Bars.tsx
+++ b/applications/client/src/views/Campaign/Timeline/Bars.tsx
@@ -67,43 +67,43 @@ export const Bars = observer<BarsProps>(({ xScale, bars, start, end, dimensions,
 									state.toggleIsHover();
 								}}
 							>
-								{/* Interaction Beacon Bar for color */}
 								{bar.beaconCount && (
-									<rect
-										x={x}
-										width={width}
-										y={0}
-										height={dimensions.height}
-										css={[baseBarStyles, interactionBarStyles(isOpen)]}
-									/>
-								)}
-								{/* Dead & Future Beacon Bar */}
-								<rect
-									x={x}
-									width={width}
-									y={dimensions.height - yScale(bar.beaconCount)}
-									height={yScale(bar.beaconCount)}
-									css={[baseBarStyles, scrubberTime && bar.end <= scrubberTime ? deadBarStyles : futureBarStyles]}
-								/>
-								{/* Active Beacon Bar */}
-								<rect
-									x={x}
-									width={width}
-									y={dimensions.height - yScale(bar.activeBeaconCount)}
-									height={yScale(bar.activeBeaconCount)}
-									css={[baseBarStyles, aliveBarStyles]}
-								/>
-								{/* Selected Beacon Bar */}
-								<animated.rect
-									x={x}
-									width={width}
-									y={dimensions.height - yScale(bar.selectedBeaconCount)}
-									height={yScale(bar.selectedBeaconCount)}
-									css={[baseBarStyles, selectedBarStyles]}
-								/>
-								{/* Interaction Beacon Bar for Functionality */}
-								{!!bar.beaconCount && (
-									<rect x={x} width={width} y={0} height={dimensions.height} css={[interactionBarFnStyles]} />
+									<>
+										{/* Interaction Beacon Bar for color */}
+										<rect
+											x={x}
+											width={width}
+											y={0}
+											height={dimensions.height}
+											css={[baseBarStyles, interactionBarStyles(isOpen)]}
+										/>
+										{/* Dead & Future Beacon Bar */}
+										<rect
+											x={x}
+											width={width}
+											y={dimensions.height - yScale(bar.beaconCount)}
+											height={yScale(bar.beaconCount)}
+											css={[baseBarStyles, scrubberTime && bar.end <= scrubberTime ? deadBarStyles : futureBarStyles]}
+										/>
+										{/* Active Beacon Bar */}
+										<rect
+											x={x}
+											width={width}
+											y={dimensions.height - yScale(bar.activeBeaconCount)}
+											height={yScale(bar.activeBeaconCount)}
+											css={[baseBarStyles, aliveBarStyles]}
+										/>
+										{/* Selected Beacon Bar */}
+										<animated.rect
+											x={x}
+											width={width}
+											y={dimensions.height - yScale(bar.selectedBeaconCount)}
+											height={yScale(bar.selectedBeaconCount)}
+											css={[baseBarStyles, selectedBarStyles]}
+										/>
+										{/* Interaction Beacon Bar for Functionality */}
+										<rect x={x} width={width} y={0} height={dimensions.height} css={[interactionBarFnStyles]} />
+									</>
 								)}
 							</g>
 						)}

--- a/applications/server/src/store/command-group-resolvers.ts
+++ b/applications/server/src/store/command-group-resolvers.ts
@@ -60,10 +60,12 @@ export class CommandGroupResolvers {
 		const em = await connectToProjectEmOrFail(campaignId, ctx);
 		let commandGroups: CommandGroup[] = [];
 		if (commandGroupIds?.length) {
-			const query: FilterQuery<CommandGroup> = {
-				id: commandGroupIds,
-				commands: { ...beaconHidden(hidden) },
-			};
+			const query: FilterQuery<CommandGroup> = hidden
+				? { id: commandGroupIds }
+				: {
+						id: commandGroupIds,
+						commands: { ...beaconHidden(hidden) },
+				  };
 			commandGroups = await em.find(CommandGroup, query, {
 				populate: relationPaths,
 				orderBy: filter,


### PR DESCRIPTION
## 🗣 Description ##

Resolve #6

- [ ] Quick metadata editing button was implemented for Server, Host and Beacon:
- When "Show Hidden Beacons, Host, and Servers" toggle is off,
-- quick editing button to hide a Server/Host/Beacon 
- When "Show Hidden Beacons, Host, and Servers" toggle is on, 
-- quick editing button to Show/Hide a Server/Host/Beacon
-- a viewOff icon to indicate it's hidden
- [ ] Beacon Meta Tab update:
- Show/Hide Beacon will route to Beacons Tab instead of Hosts Tab