### PR TITLE
Red Team / Blue Team Disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ Follow the User Guide to learn about the RedEye feature set.
 ## Quick start
 1. **Download** the latest RedEye binaries for [your OS](#platform-support) from the [Releases](https://github.com/cisagov/RedEye/releases) page.
 2. **Pick a mode** and **Run the server**
-	- [ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run in the command line:
+	- [ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run the following in a terminal. _You must provide a password to run in RedTeam mode._
 		```
 		AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
 		```
-		You must provide a password to run in RedTeam mode.
 	- [**Blue Team mode**](#blue-team) (default) enables a simplified, read-only UI for reviewing campaigns exported by a Red Team. To start the server in Blue Team mode. Double-click on the 'RedEye' executable or run `./RedEye` from the command line.
 3. **Use the web app** in a browser at http://127.0.0.1:4000. The RedEye binary runs as a server in a terminal window and will automatically open the web app UI your default browser. You must close the terminal window to quit the RedEye server.
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Follow the User Guide to learn about the RedEye feature set.
 1. **Download** the latest RedEye binaries for [your OS](#platform-support) from the [Releases](https://github.com/cisagov/RedEye/releases) page.
 2. **Pick a mode** and **Run the server**
 	- [ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run in the command line:
-	```
-	AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
-	```
-	  You must provide a password to run in RedTeam mode.
+		```
+		AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
+		```
+			You must provide a password to run in RedTeam mode.
 	- [**Blue Team mode**](#blue-team) (default) enables a simplified, read-only UI for reviewing campaigns exported by a Red Team. To start the server in Blue Team mode. Double-click on the 'RedEye' executable or run `./RedEye` from the command line.
 3. **Use the web app** in a browser at http://127.0.0.1:4000. The RedEye binary runs as a server in a terminal window and will automatically open the web app UI your default browser. You must close the terminal window to quit the RedEye server.
 
@@ -49,9 +49,9 @@ There are three options to run RedEye in Red Team mode:
 	1. Clone the repo
 	2. Update the environment variables in `docker-compose.yml`.
 	3. Run: 
-	```
-	docker-compose -f docker-compose.yml up -d redeye-core
-	```
+		```
+		docker-compose -f docker-compose.yml up -d redeye-core
+		```
 
 ### Blue Team
 The Blue Team mode is a simplified, read-only UI for displaying data that has been curated, annotated, and exported by a Red Team. This mode runs by default to make startup more simple for the Blue Team.

--- a/README.md
+++ b/README.md
@@ -1,136 +1,93 @@
 # RedEye
-
 Red Team C2 Log Visualization
 
 ![RedEye Screenshot](docs/images/RedEye-Hero-Screenshot.png)
 
-RedEye is an open-source analytic tool developed by CISA and DOE’s Pacific Northwest National Laboratory to assist Red Teams with visualizing and reporting command and control activities. This tool, released in October 2022 on GitHub, allows an operator to assess and display complex data, evaluate mitigation strategies, and enable effective decision making in response to a Red Team assessment. The tool parses logs, such as those from Cobalt Strike, and presents the data in an easily digestible format. The users can then tag and add comments to activities displayed within the tool. The operators can use the RedEye’s presentation mode to present findings and workflow to stakeholders.
+RedEye is an open-source analytic tool developed by [CISA](https://www.cisa.gov/) and [DOE](https://www.energy.gov/)’s [Pacific Northwest National Laboratory](https://www.pnnl.gov/) to assist [Red Teams](https://en.wikipedia.org/wiki/Red_team) with visualizing and reporting command and control activities. This tool, released in October 2022 on GitHub, allows an operator to assess and display complex data, evaluate mitigation strategies, and enable effective decision making in response to a Red Team assessment. The tool parses logs, such as those from [Cobalt Strike](https://www.cobaltstrike.com/), and presents the data in an easily digestible format. The users can then tag and add comments to activities displayed within the tool. The operators can use the RedEye’s presentation mode to present findings and workflow to stakeholders.
 
 RedEye can assist an operator to efficiently:
-
 - Replay and demonstrate Red Team’s assessment activities as they occurred rather than manually pouring through thousands of lines of log text.
 - Display and evaluate complex assessment data to enable effective decision making.
 - Gain a clearer understanding of the attack path taken and the hosts compromised during a Red Team assessment or penetration test.
 
-Red Team:
-[![Red Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/rsybgk&style=flat&logo=cypress)](https://cloud.cypress.io/projects/rsybgk/runs)
-
-Blue Team:
-[![Blue Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/46ahz3&style=flat&logo=cypress)](https://cloud.cypress.io/projects/46ahz3/runs)
+Red Team: [![Red Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/rsybgk&style=flat&logo=cypress)](https://cloud.cypress.io/projects/rsybgk/runs)
+Blue Team: [![Blue Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/46ahz3&style=flat&logo=cypress)](https://cloud.cypress.io/projects/46ahz3/runs)
 
 ## [User Guide](<docs/User Guide.md>)
+Follow the User Guide to learn about the RedEye feature set.
 
 ## Quick start
+1. **Download** the latest RedEye binaries for [your OS](#platform-support) from the [Releases](https://github.com/cisagov/RedEye/releases) page.
+2. **Pick a mode** and **Run the server**
+	-[ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run in the command line:
+	```
+	AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
+	```
+	  You must provide a password to run in RedTeam mode.
+	- [**Blue Team mode**](#blue-team) (default) enables a simplified, read-only UI for reviewing campaigns exported by a Red Team. To start the server in Blue Team mode. Double-click on the 'RedEye' executable or run `./RedEye` from the command line.
+3. **Use the web app** in a browser at http://127.0.0.1:4000. The RedEye binary runs as a server in a terminal window and will automatically open the web app UI your default browser. You must close the terminal window to quit the RedEye server.
 
-The fastest way to get up and running is by downloading the latest `RedEye` binaries for your operating system in the [Releases](https://github.com/cisagov/RedEye/releases) section on GitHub.
+_**MacOS Issue** - When running RedEye for the first time, you may get a "not verified" error. You must go to "System Preferences" > "Security & Privacy" > "General" and click "Open Anyway." More info on the [apple support page](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/)._
 
-RedEye currently supports uploading Cobalt Strike logs and offers both Red Team and Blue Team modes.
+## Red Team & Blue Team Modes
+RedEye has two modes that cover two stages of the Red Teaming process. [Red Team mode](#red-team) allows for import of C2 data, editing of imported data, and make comments and presentations. After curating and annotating the campaign data, the Red Team can export the campaign as a standalone .redeye file and [hand off to a Blue Team](#blue-team-presentation-handoff) for reporting and remediation. [Blue Team mode](#blue-team) runs RedEye in a simplified read-only mode for viewing curated data exported by a Red Team.
 
-- The Red Team mode offers the ability to upload campaign logs, explore, and create presentations. This mode is started by running RedEye with the `SERVER_BLUE_TEAM=false` environment variable or the
-  `--redTeam` argument.
-- The Blue Team mode enables the ability to review a read-only campaign exported by a Red Team. This mode runs by default.
-
-Note: Both Red and Blue Team modes can be started from the same `RedEye` application binary.
-
-### Blue Team
-
-The Blue Team version can be run by double-clicking the `RedEye` application binary.
-
-`RedEye` runs by default at `http://127.0.0.1:4000` and will automatically open your default browser.
-
-If a `campaigns` folder is located in the same directory as the `RedEye` application, RedEye will attempt to import any `.redeye` campaign files within. Campaign files can be exported in the "Red Team" version.
-
-To prepare a version for the Blue Team, follow these two steps:
-
-1. Copy the `RedEye` application binary to an empty folder.
-2. Create a `campaigns` folder in the same directory and place the `.redeye` campaign files you want to send inside.
+_Note: Both Red and Blue Team modes can be started from the same RedEye application binary._
 
 ### Red Team
+The downloaded binary comes in two parts:
+- The `RedEye` application binary
+- The `parsers` folder containing the `cs-parser` Cobalt Strike log parser binary
 
-The Red Team version comes in two parts:
+There are three options to run RedEye in Red Team mode:
+1. Run the downloaded binary, passing in the `--redTeam` and password options:
+	```
+	AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
+	```
+2. Clone, install, and run the project directly (covered in the [Local Build](#local-build) section).
+3. Docker Compose
+	1. Clone the repo
+	2. Update the environment variables in `docker-compose.yml`.
+	3. Run: 
+	```
+	docker-compose -f docker-compose.yml up -d redeye-core
+	```
 
-- The `RedEye` application binary and
-- The `parsers` folder containing the `cs-parser` Cobalt Strike log parser binary.
+### Blue Team
+The Blue Team mode is a simplified, read-only UI for displaying data that has been curated, annotated, and exported by a Red Team. This mode runs by default to make startup more simple for the Blue Team.
 
-There are two options to run RedEye:
+The Blue Team version can be run by double-clicking the 'RedEye' application binary. RedEye runs at http://127.0.0.1:4000 (by default) and will automatically open your default browser.
 
-1. Run the downloaded binary: `AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam`.
-2. Clone this repository and either:
-   <ol type="A">
-    <li>Docker Compose:</li>
-       <ol type="i">
-        <li>Update the environment variables in `docker-compose.yml`.</li>
-        <li>Run: `docker-compose -f docker-compose.yml up -d redeye-core`.</li>
-       </ol>
-    <li>Install and run the project directly (covered in the <a href="#local-build">Local Build</a> section).</li>
-   </ol>
+### Blue Team Presentation Handoff
+If a `campaigns` folder is located in the same directory as the `RedEye` application, RedEye will attempt to import any `.redeye` campaign files within. Campaign files can be exported in the Red Team mode.
 
-The application runs by default at `http://127.0.0.1:4000`.
+To prepare a version for the Blue Team, follow these two steps:
+1. Copy the `RedEye` application binary to an empty folder.
+2. Create a `campaigns` folder in the same directory and place the `.redeye` campaign files you want to send inside.
+```
+Folder/
+	RedEye
+	campaigns/
+		Campaign-01.redeye
+		Campaign-02.redeye
+```
+`.redeye` files can also be uploaded in Blue Team mode via the "+ Add Campaign" dialog.
 
-## Platform support
-
-- Linux
-  - Ubuntu 18 and newer
-  - Kali Linux 2020.1 and newer
-  - Others may be supported but are untested
-- macOS
-  - El Capitan and newer
-- Windows
-  - Windows 7 and newer
-
-ARM support is experimental
-
-_Note: For Mac users, when first running the `RedEye` application (and `cs-parser` if using the Red Team version), you must go to "System Preferences" then "Security & Privacy" and click "Open Anyway"._
-
-## Local Build
-
-### Required Packages
-
-- [Node.js](https://nodejs.org/en/) >= v16
-
-- Install yarn: `npm install -g yarn`
-- Run: `yarn install` // Installs all packages
-- Run either:
-  1. `yarn release:all` to build a binary for Linux, macOS, and Windows
-  2. `yarn release:(mac|windows|linux)` to build for a specific platform.
-  - platform options:
-    - mac
-    - windows
-    - linux
-
-## Development
-
-### Setup
-
-- Install yarn: `npm install -g yarn`
-- Run: `yarn install` // Installs all packages
-
-#### Quick Start Development
-
-Runs the project in development mode
-
-```sh
-yarn run start
+## RedEye Server Settings
+RedEye runs as a server and can be setup to serve the UI on a network
+***{instructions}***
+### RedEye Server parameters
+Type `./Redeye -h` to view the options
+```
+-d, --developmentMode [boolean]  put the database and server in development mode
+-r, --redTeam [boolean]          run the server in red team mode
+-p, --port [number]              the port the server should be exposed at
+-t, --childProcesses [number]    max # of child processes the parser can use
+-h, --help                       display help for command
 ```
 
-#### Advanced Development
-
-It is recommended to run the server and client in two separate terminals
-
-```sh
-yarn run start:client
-```
-
-```sh
-yarn run start:server
-```
-
-#### Build
-
-`yarn build` to build all applications and their dependent libraries
-
-#### Server .env example
-
+you can also configure the sever parameters in an `.env` file that sits next to the `RedEye` binary
+***{is this true?}***
 ```env
 AUTHENTICATION_PASSWORD=937038570
 AUTHENTICATION_SECRET=supertopsecretdonttellanyone
@@ -139,9 +96,72 @@ SERVER_BLUE_TEAM=false
 SERVER_PRODUCTION=false
 ```
 
+## Local Build
+### Required Packages
+- [Node.js](https://nodejs.org/en/) >= v16
+- Install yarn: `npm install -g yarn`
+- Run: `yarn install` // Installs all packages
+- Run either:
+	1. `yarn release:all` to build a binary for Linux, macOS, and Windows
+	2. `yarn release:(mac|windows|linux)` .
+- platform options:
+	- mac
+	- windows
+	- linux
+## Development
+### Setup
+Install [Node.js](https://nodejs.org/en/) >= v16 ***{is this true? my v18 doesn't work?}***
+Install [yarn](https://yarnpkg.com/) globally via [npm](https://www.npmjs.com/package/yarn)
+```
+npm install -g yarn
+```
+Install package dependencies
+```
+yarn install
+```
+#### Quick Start Development
+Runs the project in development mode
+```sh
+yarn start
+```
+#### Advanced Development
+It is recommended to run the server and client in two separate terminals
+```sh
+yarn start:client
+```
+...in another terminal
+```sh
+yarn start:server
+```
+#### Build
+to build a binary for Linux, macOS, and Windows
+```shell
+yarn release:all
+```
+to build for a specific platform, replace `all` with the platform name
+```shell
+yarn release:(mac|windows|linux)
+```
+
+## Platform support
+- Linux
+	- Ubuntu 18 and newer
+	- Kali Linux 2020.1 and newer
+	- Others may be supported but are untested
+- macOS
+	- El Capitan and newer
+- Windows
+	- Windows 7 and newer
+ARM support is experimental
+
+
 ---
 
+
 <div align="center">
-  <img alt="CISA Logo" src="docs/images/CISA Logo.png" height="35%" width="35%"/>
-  <img alt="RedEye Logo" src="applications/client/public/logos/Logo-Dark.svg" height="35%" width="35%"/>
+
+<img alt="CISA Logo" src="docs/images/CISA Logo.png" height="35%" width="35%"/>
+
+<img alt="RedEye Logo" src="applications/client/public/logos/Logo-Dark.svg" height="35%" width="35%"/>
+
 </div>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Follow the User Guide to learn about the RedEye feature set.
 ## Quick start
 1. **Download** the latest RedEye binaries for [your OS](#platform-support) from the [Releases](https://github.com/cisagov/RedEye/releases) page.
 2. **Pick a mode** and **Run the server**
-	-[ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run in the command line:
+	- [ **Red Team mode**](#red-team) enables the full feature set: upload C2 logs, explore data, and create presentations. To start the server in Red Team mode, run in the command line:
 	```
 	AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
 	```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RedEye can assist an operator to efficiently:
 - Gain a clearer understanding of the attack path taken and the hosts compromised during a Red Team assessment or penetration test.
 
 Red Team: [![Red Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/rsybgk&style=flat&logo=cypress)](https://cloud.cypress.io/projects/rsybgk/runs)
+
 Blue Team: [![Blue Team](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/simple/46ahz3&style=flat&logo=cypress)](https://cloud.cypress.io/projects/46ahz3/runs)
 
 ## [User Guide](<docs/User Guide.md>)
@@ -23,7 +24,7 @@ Follow the User Guide to learn about the RedEye feature set.
 		```
 		AUTHENTICATION_PASSWORD=<your_password> ./RedEye --redTeam
 		```
-			You must provide a password to run in RedTeam mode.
+		You must provide a password to run in RedTeam mode.
 	- [**Blue Team mode**](#blue-team) (default) enables a simplified, read-only UI for reviewing campaigns exported by a Red Team. To start the server in Blue Team mode. Double-click on the 'RedEye' executable or run `./RedEye` from the command line.
 3. **Use the web app** in a browser at http://127.0.0.1:4000. The RedEye binary runs as a server in a terminal window and will automatically open the web app UI your default browser. You must close the terminal window to quit the RedEye server.
 

--- a/applications/client/src/components/Header/AppOptions.tsx
+++ b/applications/client/src/components/Header/AppOptions.tsx
@@ -102,7 +102,7 @@ const HeaderOptions = ({
 			}}
 			rightIcon={<CarbonIcon icon={Help16} />}
 		/>
-		<ModeIndicator css={{ marginRight: -8, padding: '0px 8px' }} popoverProps={{ position: 'top-right' }} />
+		<ModeIndicator fullName css={{ marginRight: -8, padding: '0px 8px' }} popoverProps={{ position: 'top-right' }} />
 	</ButtonGroup>
 );
 

--- a/applications/client/src/components/Header/ModeIndicator.tsx
+++ b/applications/client/src/components/Header/ModeIndicator.tsx
@@ -1,64 +1,59 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { useStore } from '@redeye/client/store';
 import type { PopoverButtonProps } from '@redeye/ui-styles';
-import { CoreTokens, PopoverButton, Txt } from '@redeye/ui-styles';
+import { Flex, ExternalLink, CoreTokens, PopoverButton, Txt } from '@redeye/ui-styles';
 import { observer } from 'mobx-react-lite';
 
-export const ModeIndicator = observer<Omit<PopoverButtonProps, 'content'>>(({ popoverProps, ...props }) => {
-	const store = useStore();
-	const isRedTeam = !store.appMeta.blueTeam;
+export const ModeIndicator = observer<Omit<PopoverButtonProps, 'content'> & { fullName?: boolean }>(
+	({ popoverProps, fullName, ...props }) => {
+		const store = useStore();
+		const isRedTeam = !store.appMeta.blueTeam;
 
-	let teamAcronym: string = 'BT';
-	let team: string = 'Blue Team ';
-	let description: string = 'Restricted RedEye functionality. Editing and commenting features are not available.';
-	let teamCSS: SerializedStyles = blueStyle;
+		let teamAcronym = fullName ? 'Blue Team' : 'BT';
+		let team = 'Blue Team';
+		let description = 'Restricted RedEye functionality. Editing and commenting features are not available.';
+		let teamCSS = blueStyle;
 
-	if (isRedTeam) {
-		teamAcronym = 'RT';
-		team = 'Red Team ';
-		description = 'Full RedEye functionality. Editing and commenting is not restricted.';
-		teamCSS = redStyle;
-	}
+		if (isRedTeam) {
+			teamAcronym = fullName ? 'Red Team' : 'RT';
+			team = 'Red Team';
+			description = 'Full RedEye functionality. Editing and commenting is not restricted.';
+			teamCSS = redStyle;
+		}
 
-	return (
-		<PopoverButton
-			popoverProps={{
-				position: 'right',
-				interactionKind: 'hover',
-				...popoverProps,
-			}}
-			content={
-				<div css={hoverInfoStyle}>
-					<Txt large bold>
-						<Txt>{team}</Txt> <Txt muted>Mode </Txt>
-					</Txt>
-					<Txt muted>{description}</Txt>
+		return (
+			<PopoverButton
+				popoverProps={{
+					position: 'right',
+					interactionKind: 'hover',
+					...popoverProps,
+				}}
+				content={
+					<Flex column gap={4} align="start" css={{ width: 320, padding: 12 }}>
+						<Txt large bold>
+							<Txt>{team}</Txt> <Txt muted>Mode</Txt>
+						</Txt>
+						<Txt muted>{description}</Txt>
+						<ExternalLink href="https://github.com/cisagov/redeye#readme">Learn more</ExternalLink>
+					</Flex>
+				}
+				active={false}
+				{...props}
+			>
+				<div cy-test={teamAcronym} css={teamCSS}>
+					{teamAcronym}
 				</div>
-			}
-			active={false}
-			{...props}
-		>
-			<div cy-test={teamAcronym} css={teamCSS}>
-				{teamAcronym}
-			</div>
-		</PopoverButton>
-	);
-});
-
-const hoverInfoStyle = css`
-	display: flex;
-	flex-direction: column;
-	padding: 12px;
-	width: 23em;
-	gap: 4px;
-`;
+			</PopoverButton>
+		);
+	}
+);
 
 const indicatorStyle = css`
 	padding: 2px;
 	font-weight: 800;
 	font-size: 11px;
 	line-height: 11px;
+	text-transform: uppercase;
 	color: ${CoreTokens.Colors.Black};
 `;
 

--- a/applications/client/src/components/Header/ModeIndicator.tsx
+++ b/applications/client/src/components/Header/ModeIndicator.tsx
@@ -34,7 +34,7 @@ export const ModeIndicator = observer<Omit<PopoverButtonProps, 'content'> & { fu
 							<Txt>{team}</Txt> <Txt muted>Mode</Txt>
 						</Txt>
 						<Txt muted>{description}</Txt>
-						<ExternalLink href="https://github.com/cisagov/redeye#readme">Learn more</ExternalLink>
+						<ExternalLink href="https://github.com/cisagov/redeye#red-team--blue-team-modes">Learn more</ExternalLink>
 					</Flex>
 				}
 				active={false}

--- a/applications/client/src/views/Campaigns/Upload/NewCampaignDialog.tsx
+++ b/applications/client/src/views/Campaigns/Upload/NewCampaignDialog.tsx
@@ -75,7 +75,7 @@ const shadowStyle = css`
 
 const BlueTeamSourceWarning = (props) => (
 	<div css={{ padding: 24 }} {...props}>
-		<Txt running>
+		<Txt cy-test="bt-warning" running>
 			This upload source is not available in BlueTeam mode.
 			<br />
 			<ExternalLink href="https://github.com/cisagov/redeye#red-team--blue-team-modes">Learn more</ExternalLink>

--- a/applications/client/src/views/Campaigns/Upload/NewCampaignDialog.tsx
+++ b/applications/client/src/views/Campaigns/Upload/NewCampaignDialog.tsx
@@ -78,7 +78,7 @@ const BlueTeamSourceWarning = (props) => (
 		<Txt running>
 			This upload source is not available in BlueTeam mode.
 			<br />
-			<ExternalLink href="https://github.com/cisagov/redeye#readme">Learn more</ExternalLink>
+			<ExternalLink href="https://github.com/cisagov/redeye#red-team--blue-team-modes">Learn more</ExternalLink>
 		</Txt>
 	</div>
 );

--- a/applications/redeye-e2e/src/integration/e2e/blueteam/verify-blueteam-version.cy.js
+++ b/applications/redeye-e2e/src/integration/e2e/blueteam/verify-blueteam-version.cy.js
@@ -6,6 +6,10 @@ describe('Verify Blue Team Version', () => {
 
 		cy.get('[cy-test=upload-from-file]').should('be.visible');
 
-		cy.get('[cy-test=create-new-camp]').should('not.exist');
+		cy.get('[cy-test=create-new-camp]').click();
+
+		cy.get('[cy-test=bt-warning]')
+			.should('be.visible')
+			.and('contain.text', 'This upload source is not available in BlueTeam mode.');
 	});
 });

--- a/applications/server/src/asciiArt.ts
+++ b/applications/server/src/asciiArt.ts
@@ -33,16 +33,16 @@ export const consoleFormatting = {
 const cf = consoleFormatting;
 
 const o = cf.reset + cf.lightGray; // outline
-const c = cf.reset + cf.red + cf.bold; // center
+const c = (blue = false) => cf.reset + (blue ? cf.blue : cf.red) + cf.bold; // center
 const t = cf.reset + cf.white + cf.bold; //cf.red // text
 
-export const asciiArt = `${o}
+export const asciiArt = (b = false) => `${o}
         ___________
        /           \\
       /    _________\\
   \\¯¯/    /     \\ _-¯
-   \\/    /  ${c}▗▄▖${o}  ¯_____     ${t}__  ___ __   ___    ___${o}  
-    ¯¯¯¯¯_  ${c}▝▀▘${o}  /    /\\   ${t}|__)|__ |  \\ |__ \\ /|__${o}  
+   \\/    /  ${c(b)}▗▄▖${o}  ¯_____     ${t}__  ___ __   ___    ___${o}  
+    ¯¯¯¯¯_  ${c(b)}▝▀▘${o}  /    /\\   ${t}|__)|__ |  \\ |__ \\ /|__${o}  
       _-¯ \\     /    /__\\  ${t}|  \\|___|__/ |___ | |___${o}  
       \\¯¯¯¯¯¯¯¯¯    /
        \\           /

--- a/applications/server/src/machines/http.service.ts
+++ b/applications/server/src/machines/http.service.ts
@@ -31,15 +31,17 @@ const serverStartLogs = async (ctx: ServerMachineContext, clientUrl?: string): P
 
 	const logLine: string[] = [``];
 
-	// if (ctx.config.production)
-	logLine.push(asciiArt);
+	logLine.push(asciiArt()); // ctx.config.blueTeam));
 
 	const ver = `v${packageJson.version}`;
-	const helpLink = 'https://github.com/cisagov/redeye';
+
+	const helpLink = 'https://github.com/cisagov/redeye#readme';
+	const mode = ctx.config.blueTeam ? `${cf.blueBg} BLUE TEAM ${cf.reset}` : `${cf.redBg} RED TEAM ${cf.reset}`;
 
 	logLine.push(
-		`  ${cf.bold}${cf.white}RedEye Server${cf.reset} ${cf.dim}${ver}${cf.reset}`,
+		`  ${cf.bold}${cf.white}RedEye Server${cf.reset} ${ver}${cf.reset}`,
 		`  RedEye Client ${cf.blue}${cf.underlined}${usedClientUrl}${cf.reset}`,
+		`  Running in ${mode} mode`,
 		`  Visit ${cf.underlined}${helpLink}${cf.reset} for help`,
 		`  To quit, close terminal window or press ^C`,
 		``


### PR DESCRIPTION
NOTE! this PR is stacked onto `add-campaign-form-tweaks` so that the diff is more accurate. So when it's merged, we will need to make sure the right changes are added to `develop`. 

## Description ##
- updated Readme - see [Github preview](https://github.com/cisagov/RedEye/tree/red-team-blue-team-disambiguation#readme)
- Add a mode indicator to the Server log output
- Added a full text description of Red/Blue Team on the homepage
- Added a link from the Red/Blue Team ModeIndicator Popover to the (future) ReadMe.md.

## Testing ##
- Read [ReadMe.md](https://github.com/cisagov/RedEye/tree/red-team-blue-team-disambiguation#readme)
- Does the server log output include the proper Red or Blue team output?

## TODO ##
- [ ] ReadMe.md has some questions and content that need review. See comments in the chain below.

## Screenshots ##
<img width="697" alt="Screen Shot 2023-03-21 at 2 42 09 PM" src="https://user-images.githubusercontent.com/6248614/226749477-0afc031c-a8ca-4613-b1a0-06f8de9fd5f1.png">

![Screen Shot 2023-03-21 at 2 46 01 PM](https://user-images.githubusercontent.com/6248614/226749666-9331ee66-4a2e-41c3-b75e-da2edbe611f5.png)


