### PR TITLE
Persist Left Panel Resize

### DIFF
--- a/applications/client/src/components/DragResize.tsx
+++ b/applications/client/src/components/DragResize.tsx
@@ -130,6 +130,7 @@ export const DragResize = observer<DragResizeProps>(
 		});
 
 		const wrapperElementRef = useRef<HTMLDivElement>(null);
+		const dragElementRef = useRef<HTMLDivElement>(null);
 
 		// update the full and max width when the screen changes size
 		useEffect(() => {
@@ -145,6 +146,11 @@ export const DragResize = observer<DragResizeProps>(
 			},
 			onDragStart: () => {
 				state.update('isDragging', true);
+				const dragElement = dragElementRef?.current;
+				const parentElement = wrapperElementRef?.current;
+				const columnWidthPrevious =
+					!dragElement || !parentElement ? state.columnWidth : dragElement.offsetLeft - parentElement.offsetLeft;
+				state.update('columnWidthPrevious', columnWidthPrevious);
 			},
 			onDragEnd: () => {
 				state.update('isDragging', false);
@@ -166,7 +172,7 @@ export const DragResize = observer<DragResizeProps>(
 				{/* we need to keep these components mounted, so use hidden={isCollapsed} */}
 				<GridCell hidden={!state.collapsedFixed}>{fixedCollapsedContent(state.commandProps)}</GridCell>
 				<GridCell hidden={state.collapsedFixed}>{fixedContent(state.commandProps)}</GridCell>
-				<div css={draggerWrapperStyle} {...bind()}>
+				<div ref={dragElementRef} css={draggerWrapperStyle} {...bind()}>
 					<DraggerComponent isDragging={state.isDragging} />
 				</div>
 				<GridCell hidden={!state.collapsedFluid}>{fluidCollapsedContent(state.commandProps)}</GridCell>

--- a/applications/client/src/components/DragResize.tsx
+++ b/applications/client/src/components/DragResize.tsx
@@ -55,8 +55,8 @@ export const DragResize = observer<DragResizeProps>(
 		...props
 	}) => {
 		const state = createState({
-			columnWidthPrevious: columnWidthDefault,
-			columnWidth: columnWidthDefault,
+			columnWidthPrevious: getColumnWidthStorage(columnWidthDefault),
+			columnWidth: getColumnWidthStorage(columnWidthDefault),
 			collapsedFixed: collapsedFixedDefault && !collapsedFluidDefault,
 			collapsedFluid: collapsedFluidDefault && !collapsedFixedDefault,
 			isDragging: false,
@@ -64,6 +64,12 @@ export const DragResize = observer<DragResizeProps>(
 			collapsedMaxWidth: collapsedMinWidth * 2,
 			get commandProps() {
 				return { collapseFixed: this.collapseFixed, collapseFluid: this.collapseFluid, reset: this.reset };
+			},
+			get columnWidthStorage() {
+				return getColumnWidthStorage(columnWidthDefault);
+			},
+			set columnWidthStorage(columnWidth: number) {
+				window.localStorage.setItem(columnWidthId, columnWidth.toString());
 			},
 			collapseFixed() {
 				this.columnWidth = 0;
@@ -83,8 +89,8 @@ export const DragResize = observer<DragResizeProps>(
 			},
 			reset() {
 				if (this.isDragging) return;
-				this.columnWidth = columnWidthDefault;
-				this.columnWidthPrevious = columnWidthDefault;
+				this.columnWidth = this.columnWidthStorage;
+				this.columnWidthPrevious = this.columnWidthStorage;
 				if (this.collapsedFixed) this.collapsedFixed = false;
 				if (this.collapsedFluid) this.collapsedFluid = false;
 			},
@@ -143,6 +149,9 @@ export const DragResize = observer<DragResizeProps>(
 			onDragEnd: () => {
 				state.update('isDragging', false);
 				state.update('columnWidthPrevious', state.columnWidth);
+				if (!state.collapsedFixed && !state.collapsedFluid) {
+					state.update('columnWidthStorage', state.columnWidth);
+				}
 			},
 		});
 
@@ -166,6 +175,10 @@ export const DragResize = observer<DragResizeProps>(
 		);
 	}
 );
+
+const columnWidthId = 'columnWidth';
+const getColumnWidthStorage = (defaultWidth = 0) =>
+	parseInt(window.localStorage.getItem(columnWidthId) || defaultWidth.toString(), 10);
 
 const wrapperStyle = css`
 	display: grid;

--- a/applications/client/src/components/DragResize.tsx
+++ b/applications/client/src/components/DragResize.tsx
@@ -65,6 +65,8 @@ export const DragResize = observer<DragResizeProps>(
 			get commandProps() {
 				return { collapseFixed: this.collapseFixed, collapseFluid: this.collapseFluid, reset: this.reset };
 			},
+			// persisting the collapsedFluid state in window.localStorage breaks graph layout
+			// revert 9e3203e3 to restore this functionality
 			get columnWidthStorage() {
 				return getColumnWidthStorage(columnWidthDefault);
 			},
@@ -87,10 +89,12 @@ export const DragResize = observer<DragResizeProps>(
 					this.columnWidthPrevious = this.fullWidth;
 				}
 			},
-			reset() {
+			reset(forceWidth?: number) {
 				if (this.isDragging) return;
-				this.columnWidth = this.columnWidthStorage;
-				this.columnWidthPrevious = this.columnWidthStorage;
+				const setWidth = forceWidth || this.columnWidthStorage;
+				this.columnWidth = setWidth;
+				this.columnWidthPrevious = setWidth;
+				this.columnWidthStorage = setWidth;
 				if (this.collapsedFixed) this.collapsedFixed = false;
 				if (this.collapsedFluid) this.collapsedFluid = false;
 			},
@@ -158,6 +162,9 @@ export const DragResize = observer<DragResizeProps>(
 				if (!state.collapsedFixed && !state.collapsedFluid) {
 					state.update('columnWidthStorage', state.columnWidth);
 				}
+			},
+			onDoubleClick: () => {
+				state.reset(columnWidthDefault);
 			},
 		});
 

--- a/applications/client/src/components/DragResize.tsx
+++ b/applications/client/src/components/DragResize.tsx
@@ -49,15 +49,16 @@ export const DragResize = observer<DragResizeProps>(
 		fixedCollapsedContent = () => <DefaultFixedCollapsedComponent />,
 		fluidCollapsedContent = () => <DefaultFluidCollapsedComponent />,
 		collapsedFixed: collapsedFixedDefault = false,
-		columnWidth: columnWidthDefault = 500,
+		collapsedFixed: collapsedFluidDefault = false,
+		columnWidth: columnWidthDefault = 600,
 		collapsedMinWidth = 300,
 		...props
 	}) => {
 		const state = createState({
 			columnWidthPrevious: columnWidthDefault,
 			columnWidth: columnWidthDefault,
-			collapsedFixed: collapsedFixedDefault,
-			collapsedFluid: collapsedFixedDefault,
+			collapsedFixed: collapsedFixedDefault && !collapsedFluidDefault,
+			collapsedFluid: collapsedFluidDefault && !collapsedFixedDefault,
 			isDragging: false,
 			fullWidth: collapsedMinWidth * 2,
 			collapsedMaxWidth: collapsedMinWidth * 2,
@@ -145,16 +146,14 @@ export const DragResize = observer<DragResizeProps>(
 			},
 		});
 
-		const gridFixedColumn = `minmax(${state.collapsedFixed ? 'min-content' : 'auto'}, ${state.columnWidth}px)`;
-		const gridFluidColumn = `minmax(${state.collapsedFluid ? 'min-content' : 'auto'}, 1fr)`;
+		const gridTemplateColumns = state.collapsedFixed
+			? `auto auto 1fr`
+			: state.collapsedFluid
+			? `1fr auto auto`
+			: `${state.columnWidth}px auto 1fr`;
 
 		return (
-			<div
-				{...props}
-				ref={wrapperElementRef}
-				css={wrapperStyle}
-				style={{ gridTemplateColumns: `${gridFixedColumn} auto ${gridFluidColumn}` }}
-			>
+			<div {...props} ref={wrapperElementRef} css={wrapperStyle} style={{ gridTemplateColumns }}>
 				{/* we need to keep these components mounted, so use hidden={isCollapsed} */}
 				<GridCell hidden={!state.collapsedFixed}>{fixedCollapsedContent(state.commandProps)}</GridCell>
 				<GridCell hidden={state.collapsedFixed}>{fixedContent(state.commandProps)}</GridCell>

--- a/packages/ui-styles/src/components/Text.tsx
+++ b/packages/ui-styles/src/components/Text.tsx
@@ -138,7 +138,5 @@ export const Txt: FC<TxtProps> = ({
 		return tagName ?? (running ? 'p' : 'span');
 	}, [running, tagName]);
 
-	console.log({ RootTag });
-
 	return <RootTag css={txtCss} className={_className} {...props} />;
 };


### PR DESCRIPTION
## Description ##
Give the text content in the left panel more room for readability.
- Left Panel is now a bit larger by default - 600px
- Left Panel now persists its resize between page reloads using window.localStorage
- The drag resize now more precise
- css grid layout is simplified
- Double clicking the dragger will reset the left panel to the default size
- I made a commit that persists the collapsed state of either panel, but the graph does not initialize properly if the panel its in starts collapsed. I reverted that change and left a note.

## Testing ##
- drag resize the left panel
- reload the page

## Screenshots ##

![Screen Shot 2023-03-26 at 6 55 22 PM](https://user-images.githubusercontent.com/6248614/227823859-c4e0a4e2-3a90-49c4-b7bb-5b6a5cb2378e.png)
