### PR TITLE
Close the QuickMetaPopoverButtonMenu when ToggleHiddenDialog is closed

### DIFF
--- a/applications/client/src/views/Campaign/Explore/Panels/QuickMeta.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/QuickMeta.tsx
@@ -40,7 +40,7 @@ export const QuickMetaPopoverButtonMenu = observer<PopoverButtonProps>(({ conten
 		stopPropagation
 		icon={<CarbonIcon icon={OverflowMenuVertical16} />}
 		css={buttonStyle}
-		content={<Menu onClick={(e) => e.stopPropagation()}>{content}</Menu>}
+		content={<Menu>{content}</Menu>}
 		{...props}
 	/>
 ));

--- a/packages/ui-styles/src/components/PopoverButton.tsx
+++ b/packages/ui-styles/src/components/PopoverButton.tsx
@@ -43,6 +43,10 @@ export const PopoverButton = ({
 			)}
 			content={content}
 			{...popoverProps}
+			onClose={(e) => {
+				if (stopPropagation) e.stopPropagation();
+				popoverProps?.onClose?.(e);
+			}}
 		/>
 	);
 };


### PR DESCRIPTION
## Description ##
Before this fix, clicking 'cancel' in the ToggleHiddenDialog would not close the QuickMetaPopoverButtonMenu. Now, with the correct set of `e.stopPropagation()`s in our events. This works as its supposed to. Still not 100% sure why a click event in a detached Portal Dialog was triggering a click event on the InfoRow... but it works now.

## Testing ##
- Show/Hide Beacon/Host/Server functionality
  - with and without the 'Don't show this warning again' checked. To disable this go to devtools > Application >LocalStorage > localhost:3500 > and delete 'disableDialog' from the list (see screenshot)

![Screen Shot 2023-03-27 at 12 11 43 PM](https://user-images.githubusercontent.com/6248614/228043282-e298d57f-7b9e-4ed1-8e34-12e2d37d3790.png)



