### PR TITLE
Autosave multi pending comments

### DIFF
--- a/applications/client/src/components/Forms/LoginForm.tsx
+++ b/applications/client/src/components/Forms/LoginForm.tsx
@@ -53,6 +53,9 @@ export const LoginForm = observer<LoginFormProps>(({ onSubmit, submitText = 'Log
 					else if (loginResponse.status !== 200) this.errorMessage = 'Error logging in';
 					else {
 						this.errorMessage = '';
+						if (this.username !== store.auth.userName) {
+							window.localStorage.removeItem('pendingComments');
+						}
 						store.auth.setUser(this.username);
 						store.router.updateRoute({ path: routes[Views.CAMPAIGNS_LIST], params: { id: 'all' } });
 						if (onSubmit) onSubmit(event);

--- a/applications/client/src/store/auth.ts
+++ b/applications/client/src/store/auth.ts
@@ -40,6 +40,7 @@ export class Auth extends ExtendedModel(RedEyeModel, {
 				credentials: 'include',
 			});
 			this.appStore?.router.updateRoute({ path: RedEyeRoutes.LOGIN });
+			window.localStorage.removeItem('pendingComments');
 		} catch (e) {
 			this.appStore?.router.updateRoute({ path: RedEyeRoutes.LOGIN });
 			window.console.debug(e);

--- a/applications/client/src/views/Campaign/Explore/components/Comment/CommentBox.tsx
+++ b/applications/client/src/views/Campaign/Explore/components/Comment/CommentBox.tsx
@@ -173,7 +173,7 @@ export const CommentBox = observer<CommentBoxProps>(
 
 		const state = createState({
 			editMode: newComment || false,
-			text: annotation?.text || window.localStorage.getItem('savedComments') || '',
+			text: annotation?.text || window.localStorage.getItem('pendingComments') || '',
 			manualLinkName: '',
 			displayName: '',
 			destinationBeacon: undefined as BeaconModel | undefined,
@@ -250,11 +250,11 @@ export const CommentBox = observer<CommentBoxProps>(
 			handleTextChange(e: ChangeEvent<HTMLTextAreaElement>) {
 				this.text = e.target.value;
 				if (!this.commandGroupId && !!this.editMode) {
-					const currStoredComments = JSON.parse(window.localStorage.getItem('savedComments') || '{}');
-					delete currStoredComments[this.commandIds[0]];
+					const pendingComments = JSON.parse(window.localStorage.getItem('pendingComments') || '{}');
+					delete pendingComments[this.commandIds[0]];
 					window.localStorage.setItem(
-						'savedComments',
-						JSON.stringify({ ...currStoredComments, [this.commandIds[0]]: e.target.value })
+						'pendingComments',
+						JSON.stringify({ ...pendingComments, [this.commandIds[0]]: e.target.value })
 					);
 				}
 			},
@@ -276,9 +276,9 @@ export const CommentBox = observer<CommentBoxProps>(
 			},
 			cancelAnnotationEdit() {
 				if (!state.commandGroupId && !!state.editMode && state.text[0] === '{') {
-					const currStoredComments = JSON.parse(window.localStorage.getItem('savedComments') || '{}');
-					delete currStoredComments[this.commandIds[0]];
-					window.localStorage.setItem('savedComments', JSON.stringify(currStoredComments));
+					const pendingComments = JSON.parse(window.localStorage.getItem('pendingComments') || '{}');
+					delete pendingComments[this.commandIds[0]];
+					window.localStorage.setItem('pendingComments', JSON.stringify(pendingComments));
 				}
 				this.text = annotation?.text || '';
 				this.tags.replace(this.defaultTags);
@@ -300,14 +300,13 @@ export const CommentBox = observer<CommentBoxProps>(
 							campaignId,
 							commandIds: this.commandIds,
 							favorite: this.favorite,
-							text: JSON.parse(window.localStorage.getItem('savedComments') || '{}')[this.commandIds[0]],
+							text: JSON.parse(window.localStorage.getItem('pendingComments') || '{}')[this.commandIds[0]],
 							tags: this.tags,
 							user: store.auth.userName!,
 						});
-						// window.localStorage.removeItem('savedComments');
-						const currStoredComments = JSON.parse(window.localStorage.getItem('savedComments') || '{}');
-						delete currStoredComments[this.commandIds[0]];
-						window.localStorage.setItem('savedComments', JSON.stringify(currStoredComments));
+						const pendingComments = JSON.parse(window.localStorage.getItem('pendingComments') || '{}');
+						delete pendingComments[this.commandIds[0]];
+						window.localStorage.setItem('pendingComments', JSON.stringify(pendingComments));
 					} else if ((this.editMode || update) && annotation) {
 						yield store.graphqlStore.mutateUpdateAnnotation({
 							campaignId,
@@ -464,7 +463,7 @@ export const CommentBox = observer<CommentBoxProps>(
 								fill
 								onChange={state.handleTextChange}
 								value={
-									!state.commandGroupId && !!state.editMode && state.text[0] === '{'
+									!!state.editMode && state.text[0] === '{'
 										? JSON.parse(state.text || '{}')[state.commandIds[0]]
 										: state.text
 								}

--- a/applications/client/src/views/Campaign/Explore/components/Comment/CommentBox.tsx
+++ b/applications/client/src/views/Campaign/Explore/components/Comment/CommentBox.tsx
@@ -594,7 +594,12 @@ export const CommentBox = observer<CommentBoxProps>(
 								intent={Intent.PRIMARY}
 								alignText={Alignment.LEFT}
 								loading={state.loading}
-								disabled={state.loading || !state.text}
+								disabled={
+									state.loading ||
+									!(!!state.editMode && state.text[0] === '{'
+										? JSON.parse(state.text || '{}')[state.commandIds[0]]
+										: state.text)
+								}
 								// where the added beacon link is created
 								onClick={() => state.submitAnnotation()}
 								rightIcon={<CarbonIcon icon={semanticIcons.addComment} />}


### PR DESCRIPTION
## 🗣 Description ##
- Support auto save pending comments when creating new comments or reply to comments, even after the comment box is closed by any action
- Should support autosave for multiple commands - auto save and associate the pending comments to each corresponding command
- Should keep pending comments associated to the specific command across the campaign, including routing to other tabs via breadcrumb or refresh
- Will clear pending comments after hitting Submit or Cancel button
- Will clear pending comments after logout, or login with a different username
