### PR TITLE
Comments virtualized list bugs

### DIFF
--- a/applications/client/src/store/campaign/campaign.ts
+++ b/applications/client/src/store/campaign/campaign.ts
@@ -62,7 +62,6 @@ export class CampaignStore extends ExtendedModel(() => ({
 			hiddenCount: number;
 		}>(() => ({ groupSelect: false, selectedBeacons: [], hiddenCount: 0 })).withSetter(),
 		bulkSelectCantHideEntityIds: prop<string[]>(() => []).withSetter(),
-		commentsList: prop<{ commandGroupIds: string[] }>(() => ({ commandGroupIds: [] })).withSetter(),
 	},
 })) {
 	@observable sortMemory: {

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentGroup.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentGroup.tsx
@@ -37,6 +37,7 @@ export const CommentGroup = observer<CommentGroupProps>(
 			<div
 				css={[
 					css`
+						display: flex;
 						flex-direction: column;
 						width: 100%; // For host meta tab;
 						padding: 1px 0; // to force impossibility of block layout margin

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentGroup.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentGroup.tsx
@@ -1,17 +1,14 @@
 import { css } from '@emotion/react';
-import type { AnnotationModel, CommandGroupModel } from '@redeye/client/store';
+import type { AnnotationModel } from '@redeye/client/store';
 import { useStore } from '@redeye/client/store';
-import type { UUID } from '@redeye/client/types/uuid';
 import { CommandContainer, CommentBox, NavBreadcrumbs } from '@redeye/client/views';
 import { CoreTokens, ThemeClasses, Flex } from '@redeye/ui-styles';
 import type { Ref } from 'mobx-keystone';
 import { observer } from 'mobx-react-lite';
 import type { ComponentProps } from 'react';
-import { useEffect, useState } from 'react';
 
 export type CommentGroupProps = ComponentProps<'div'> & {
-	commandGroup?: CommandGroupModel;
-	commandGroupId?: string | null;
+	commandGroupId: string;
 	toggleNewComment: (id?: string) => void;
 	newComment: string | undefined;
 	measure?: any;
@@ -22,7 +19,6 @@ export type CommentGroupProps = ComponentProps<'div'> & {
 };
 export const CommentGroup = observer<CommentGroupProps>(
 	({
-		commandGroup,
 		commandGroupId,
 		toggleNewComment,
 		newComment,
@@ -33,22 +29,9 @@ export const CommentGroup = observer<CommentGroupProps>(
 		...props
 	}) => {
 		const store = useStore();
-		const [commandGroupId1, setCommandGroupId1] = useState<string | null | undefined>(commandGroupId);
-		const [commandGroup1, setCommandGroup1] = useState<CommandGroupModel | undefined>(commandGroup);
-		const firstCommandId = commandGroup1?.commandIds?.[0];
+		const commandGroup = store.graphqlStore.commandGroups.get(commandGroupId);
+		const firstCommandId = commandGroup?.commandIds?.[0];
 		const firstCommand = firstCommandId && store.graphqlStore.commands.get(firstCommandId);
-		useEffect(() => {
-			if (commandGroupId) {
-				// For Comments Tab
-				setCommandGroupId1(commandGroupId as UUID);
-				setCommandGroup1(store.graphqlStore.commandGroups.get(commandGroupId));
-			}
-			if (commandGroup) {
-				// For Presentation Tab
-				setCommandGroupId1(commandGroup?.id as UUID);
-				setCommandGroup1(commandGroup);
-			}
-		}, [commandGroupId, commandGroup]);
 
 		return (
 			<div
@@ -56,27 +39,29 @@ export const CommentGroup = observer<CommentGroupProps>(
 					css`
 						flex-direction: column;
 						width: 100%; // For host meta tab;
+						padding: 1px 0; // to force impossibility of block layout margin
 					`,
 					!hideCommands &&
 						css`
-							border-bottom: 1px solid ${CoreTokens.BorderMuted}; //ask ryan how to remove this
+							border-bottom: 1px solid ${CoreTokens.BorderMuted};
 						`,
 				]}
 				{...props}
 			>
-				<Flex column css={{ margin: 16 }}>
-					{commandGroup1?.annotations?.map((annotation: Ref<AnnotationModel>) => (
+				<Flex column css={{ padding: 16 }}>
+					{!commandGroup && <div css={[commentBoxStyle, { height: 300 }]} />}
+					{commandGroup?.annotations?.map((annotation: Ref<AnnotationModel>) => (
 						<CommentBox
 							key={annotation.id}
 							css={commentBoxStyle}
-							reply={() => toggleNewComment(commandGroup1?.id)}
+							reply={() => toggleNewComment(commandGroup?.id)}
 							annotation={annotation?.maybeCurrent}
-							commandGroup={commandGroup1}
+							commandGroup={commandGroup}
 							isFullList
 						/>
 					))}
-					{newComment === commandGroup1?.id && (
-						<CommentBox newComment commandGroupId={commandGroupId1} cancel={toggleNewComment} css={commentBoxStyle} />
+					{newComment === commandGroup?.id && (
+						<CommentBox newComment commandGroupId={commandGroupId} cancel={toggleNewComment} css={commentBoxStyle} />
 					)}
 				</Flex>
 				<Flex column>
@@ -92,14 +77,14 @@ export const CommentGroup = observer<CommentGroupProps>(
 						/>
 					)}
 					{!hideCommands &&
-						commandGroup1?.commandIds?.map((commandId) => (
+						commandGroup?.commandIds?.map((commandId) => (
 							<CommandContainer
-								commandGroupId={commandGroupId1}
+								commandGroupId={commandGroupId}
 								commandId={commandId}
 								css={css`
 									border-bottom: none !important;
 								`}
-								key={`${commandGroup1?.id}${commandId}`}
+								key={`${commandGroup?.id}${commandId}`}
 								hideCommentButton
 								showPath={!showPath} // configurable
 								expandedCommandIDs={expandedCommandIDs}

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/Comments.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/Comments.tsx
@@ -96,7 +96,8 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 		}
 	);
 
-	const { isLoading } = useQuery(
+	// const { isLoading: isLoadingMoreComments } = useQuery(
+	useQuery(
 		[
 			'commandGroupsById',
 			'commandGroups',
@@ -112,6 +113,7 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 				const start = index * pageSize;
 				const end = start + pageSize;
 				const ids = commandGroupIdData.commandGroupIds.slice(start, end);
+
 				// query commands as temp solution
 				const commandGroupsQuery = await store.graphqlStore.queryCommandGroups(
 					{
@@ -170,12 +172,10 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 			listRef={listRef}
 			cy-test="comments-view"
 		>
-			{commandGroupIdData?.commandGroupIds?.length === 0 ? (
-				isLoading ? (
-					<ProgressBar intent={Intent.PRIMARY} />
-				) : (
-					<MessageRow>No comments</MessageRow>
-				)
+			{!commandGroupIdData?.commandGroupIds ? (
+				<ProgressBar intent={Intent.PRIMARY} />
+			) : commandGroupIdData?.commandGroupIds?.length === 0 ? (
+				<MessageRow>No comments</MessageRow>
 			) : (
 				commandGroupIdData?.commandGroupIds?.map((commandGroupId) => (
 					<CommentGroup

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/Comments.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/Comments.tsx
@@ -38,7 +38,7 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 		},
 		visibleRange: {
 			startIndex: 0,
-			endIndex: 0,
+			endIndex: pageSize,
 		},
 		expandedCommandIDs: store.router.params.activeItemId
 			? observable.array([store.router.params.activeItemId])
@@ -184,6 +184,7 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 	);
 
 	useEffect(() => {
+		// What does this do? What is filteredData?
 		if (store.router.params.currentItem === 'comments_list' && store.router.params.currentItemId) {
 			const filteredData = commentsData?.presentationItems.find(
 				(item) => item.id === store.router.params.currentItemId
@@ -192,7 +193,7 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 				commandGroupIds: Array.from(filteredData?.commandGroupIds || []),
 			});
 		}
-	}, [store.campaign.commentsList.commandGroupIds, store.router.params.currentItem, store.router.params.currentItemId]);
+	}, [commentsData, store.router.params.currentItem, store.router.params.currentItemId]);
 
 	useEffect(() => {
 		if (store.campaign?.commentStore.scrollToComment) {
@@ -218,6 +219,7 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 		}
 	}, [data, commentsData]);
 
+	// TODO: same layout is written twice? refactor names
 	return (
 		<VirtualizedList
 			rangeChanged={(visibleRange) => state.update('visibleRange', visibleRange)}
@@ -226,9 +228,11 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 		>
 			{store.router.params.currentItem === 'comments_list' ? (
 				store.campaign.commentsList.commandGroupIds.length === 0 ? (
-					<MessageRow>No comments</MessageRow>
-				) : isCommentsDataLoading ? (
-					<ProgressBar intent={Intent.PRIMARY} />
+					isCommentsDataLoading ? (
+						<ProgressBar intent={Intent.PRIMARY} />
+					) : (
+						<MessageRow>No comments</MessageRow>
+					)
 				) : (
 					store.campaign.commentsList.commandGroupIds.map((commandGroupId) => (
 						<CommentGroup
@@ -243,9 +247,11 @@ export const Comments = observer<CommentsProps>(({ sort }) => {
 					))
 				)
 			) : data?.commandGroupIds.length === 0 ? (
-				<MessageRow>No comments</MessageRow>
-			) : isLoading ? (
-				<ProgressBar intent={Intent.PRIMARY} />
+				isLoading ? (
+					<MessageRow>No comments</MessageRow>
+				) : (
+					<ProgressBar intent={Intent.PRIMARY} />
+				)
 			) : (
 				data?.commandGroupIds.map((commandGroupId) => (
 					<CommentGroup

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
@@ -49,6 +49,7 @@ export const CommentsList = observer<CommentsListProps>(({ sort }) => {
 	// For presentationItem.id by User or Tag, make sure use a prefix in case it's same to other general types.
 	const handleClickType = useCallback((presentationItem) => {
 		store.campaign?.setCommentsList({
+			// this is also done in Comments.tsx
 			commandGroupIds: Array.from(presentationItem.commandGroupIds),
 		});
 		store.router.updateRoute({

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
@@ -48,10 +48,6 @@ export const CommentsList = observer<CommentsListProps>(({ sort }) => {
 
 	// For presentationItem.id by User or Tag, make sure use a prefix in case it's same to other general types.
 	const handleClickType = useCallback((presentationItem) => {
-		store.campaign?.setCommentsList({
-			// this is also done in Comments.tsx
-			commandGroupIds: Array.from(presentationItem.commandGroupIds),
-		});
 		store.router.updateRoute({
 			path: routes[CampaignViews.EXPLORE],
 			params: {

--- a/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Comment/CommentsList.tsx
@@ -95,8 +95,18 @@ export const CommentsList = observer<CommentsListProps>(({ sort }) => {
 						{rowTitle(presentationItem)}
 					</RowTitle>
 					<FlexSplitter />
-					<IconLabel title="Commands" value={presentationItem.commandCount} icon={semanticIcons.commands} />
-					<IconLabel title="comments" value={presentationItem.count} icon={semanticIcons.comment} />
+					<IconLabel
+						cy-test="command-count"
+						title="Commands"
+						value={presentationItem.commandCount}
+						icon={semanticIcons.commands}
+					/>
+					<IconLabel
+						cy-test="comment-count"
+						title="comments"
+						value={presentationItem.count}
+						icon={semanticIcons.comment}
+					/>
 				</InfoRow>
 			))}
 		</VirtualizedList>

--- a/applications/client/src/views/Campaign/Presentation/PresentationItem.tsx
+++ b/applications/client/src/views/Campaign/Presentation/PresentationItem.tsx
@@ -56,7 +56,7 @@ export const PresentationItem = observer<PresentationItemProps>(({ commandGroupI
 		<CommentGroup
 			cy-test="presentation-item-root"
 			showPath
-			commandGroup={data.commandGroup}
+			commandGroupId={data.commandGroup.id}
 			toggleNewComment={state.toggleNewComment}
 			newComment={state.newComment}
 			css={css`

--- a/applications/redeye-e2e/src/integration/e2e/redteam/add-delete-comments.cy.js
+++ b/applications/redeye-e2e/src/integration/e2e/redteam/add-delete-comments.cy.js
@@ -51,8 +51,12 @@ describe('Add Delete Campaign Comments', () => {
 		// Log new number of comments via Comments tab - should be 1 more
 		cy.clickExplorerMode();
 		cy.clickCommentsTab();
-		cy.viewAllComments();
-		cy.get('@commentsTabCount').should('have.length', 6);
+		cy.get('[cy-test=comment-count]')
+			.eq(0)
+			.invoke('text')
+			.then((updatedCommentCount) => {
+				expect(+updatedCommentCount).to.eq(6);
+			});
 
 		cy.returnToCampaignCard();
 		cy.searchForCampaign(camp);

--- a/applications/server/schema.graphql
+++ b/applications/server/schema.graphql
@@ -476,7 +476,7 @@ type Query {
   logsByBeaconId(beaconId: String!, campaignId: String!): [LogEntry!]!
 
   """"""
-  nonHidableEntities(beaconIds: [String!]! = [], campaignId: String!, hostIds: [String!]! = []): NonHidableEntities!
+  nonHidableEntities(beaconIds: [String!] = [], campaignId: String!, hostIds: [String!] = []): NonHidableEntities!
 
   """Get all the operators for a project"""
   operators(campaignId: String!, hidden: Boolean = false): [Operator]


### PR DESCRIPTION
## 🗣 Description ##
The Comments virtualized list scrolling was unusable. It jumped all over the place while scrolling. There were 2 issues 
- there was a sneaky margin leaking out of the CommentGroup that was Virtuoso's renderItem. ["Setting CSS margins to the content or the item elements is the Kryptonite of Virtuoso's content measuring mechanism"](https://virtuoso.dev/#gotchas:~:text=Setting%20CSS%20margins%20to%20the%20content%20or%20the%20item%20elements%20is%20the%20Kryptonite%20of%20Virtuoso%27s%20content%20measuring%20mechanism). This was fixed by adding a 1px vertical padding
- There was a circular dependency in `Comments.tsx` useEffect. The useEffect body updated a property that was also set as a dependency of the useEffect. This caused constant re-rendering of the list.

## 🧪 Testing ##
Some of the Comment list code was edited, and is pretty complex in terms of queries (TODO: should be simplified). This means that we need to test everywhere comments are present
- All / Comments / All Comments
- All / Comments / parser comments
- All / Comments / users
- All / Comments / \#Tags
- Server / Comments
- Host / Comments
- Beacon / Comments
- presentation slides

Features
- are the correct comments rendering? on the correct list
- sorting
- reloading into comment pages

## 📷 Screenshots (if appropriate) ##
