### PR TITLE
Remove Servers from Host Path

### DIFF
--- a/applications/client/src/store/graphql/CommandModel.ts
+++ b/applications/client/src/store/graphql/CommandModel.ts
@@ -78,7 +78,7 @@ export class CommandModel extends ExtendedModel(CommandModelBase, {}) {
 		const appStore = getRoot<AppStore>(this);
 		const time = appStore.settings.momentTz(this?.input?.current?.dateTime);
 		const operator = formatOperatorName(this?.operator?.current.name || 'unknown');
-		const server = this?.beacon?.current?.host?.current?.server?.displayName;
+		const server = this?.beacon?.current?.host?.current?.server?.displayName; // BLDSTRIKE-598: servers?
 		const host = this?.beacon?.current?.host?.current?.displayName;
 		const beaconName = this?.beacon?.current?.displayName;
 		const beaconUser = this?.beacon?.current?.meta?.[0]?.maybeCurrent?.username;

--- a/applications/client/src/store/graphql/HostModel.ts
+++ b/applications/client/src/store/graphql/HostModel.ts
@@ -19,6 +19,7 @@ export { selectFromHost, hostModelPrimitives, HostModelSelector } from './HostMo
  */
 @model('Host')
 export class HostModel extends ExtendedModel(HostModelBase, {
+	// BLDSTRIKE-598: should be this.serverIds plural
 	serverId: prop<string | undefined>().withSetter(),
 }) {
 	protected onAttachedToRootStore(rootStore: any): (() => void) | void {
@@ -39,6 +40,7 @@ export class HostModel extends ExtendedModel(HostModelBase, {
 	@observable.ref maxTime: Moment | undefined;
 
 	@computed get server(): ServerModel | undefined {
+		// BLDSTRIKE-598: should be this.servers plural
 		const appStore = getRoot<AppStore>(this);
 		return this.serverId ? appStore?.graphqlStore?.servers.get(this.serverId) : undefined;
 	}

--- a/applications/client/src/store/graphql/ServerModel.ts
+++ b/applications/client/src/store/graphql/ServerModel.ts
@@ -67,6 +67,7 @@ export class ServerModel extends ExtendedModel(ServerModelBase, {
 			if (beacon?.host?.maybeCurrent) {
 				getMinMaxTime(this, beacon.meta[0]?.maybeCurrent?.startTime);
 				getMinMaxTime(this, beacon.meta[0]?.maybeCurrent?.endTime);
+				// BLDSTRIKE-598: add to Array/Set host.setServerIds, don't override last
 				beacon.host?.maybeCurrent?.setServerId(this.id);
 				this.hosts.set(beacon.host.id, hostCampaignRef(beacon.host?.maybeCurrent));
 				if (beacon.host?.maybeCurrent?.cobaltStrikeServer) cobaltStrikeHost = beacon.host.maybeCurrent;

--- a/applications/client/src/views/Campaign/Explore/components/NavBreadcrumbs.tsx
+++ b/applications/client/src/views/Campaign/Explore/components/NavBreadcrumbs.tsx
@@ -107,29 +107,37 @@ export const NavBreadcrumbs = observer<NavBreadcrumbsProps>(
 							: undefined,
 					});
 
-				if (store.campaign?.interactionState.selectedCommandType)
+				if (store.campaign?.interactionState.selectedCommandType) {
 					crumbs.push({
 						text: 'Command',
 						current: true,
 					});
-				else if (store.campaign?.interactionState.selectedOperator)
+				} else if (store.campaign?.interactionState.selectedOperator) {
 					crumbs.push({
 						text: 'Operator',
 						current: true,
 					});
-				else if (store.campaign?.interactionState.selectedServer)
-					crumbs.push({
-						text: !store.campaign?.interactionState.selectedHost
-							? 'Server'
-							: store.campaign?.interactionState.selectedServer?.current?.displayName,
-						current: !store.campaign?.interactionState.selectedHost,
-						onClick: store.campaign?.interactionState.selectedHost
-							? (e) => {
-									onNavigate(e);
-									store.campaign?.interactionState.selectedServer?.current.searchSelect();
-							  }
-							: undefined,
-					});
+				} else if (store.campaign?.interactionState.selectedServer) {
+					if (!store.campaign?.interactionState.selectedHost) {
+						crumbs.push({
+							text: 'Server',
+							current: true,
+						});
+					} else if (store.campaign?.interactionState.selectedBeacon) {
+						crumbs.push({
+							text: store.campaign?.interactionState.selectedServer?.current?.displayName,
+							onClick: (e) => {
+								onNavigate(e);
+								store.campaign?.interactionState.selectedServer?.current.searchSelect();
+							},
+						});
+					} /* else { BLDSTRIKE-598
+						// const serverCount = store.campaign?.interactionState.selectedHost.current.servers.length
+						crumbs.push({
+							text: '...', // serverCount,
+						});
+					} */
+				}
 
 				if (store.campaign?.interactionState.selectedHost)
 					crumbs.push({


### PR DESCRIPTION
## 🗣 Description ##

Beacons can only be connected to one server (I think?), so they have a hierarchical location path like 'Server / Host / Beacon.' However, Hosts can contain Beacons that are connected to different Servers, so Hosts can be associated with more than one server. This PR removes the Server from the Host path until the data structure can be adjusted. 

## 🧪 Testing ##

- validate that host paths don't display an associated Server
- validate that beacon paths do display the assoicated Server

## 📷 Screenshots ##
![Screen Shot 2023-06-19 at 3 57 19 PM](https://github.com/cisagov/RedEye/assets/6248614/d913b550-1777-4ec4-b185-6198810cb2e6)

