### PR TITLE
Remove the duplicate beacon name in BeaconRow

### DIFF
--- a/applications/client/src/views/Campaign/Explore/Panels/Beacon/BeaconRow.tsx
+++ b/applications/client/src/views/Campaign/Explore/Panels/Beacon/BeaconRow.tsx
@@ -131,10 +131,9 @@ export const BeaconRow = observer<BeaconRowProps>(({ beacon, ...props }) => {
 					shape={beacon.meta?.[0]?.current?.shape || undefined}
 					color={beacon.meta?.[0]?.current?.color || undefined}
 				/>
-				<Txt cy-test="beacon-display-name" normal muted>
+				<Txt cy-test="beacon-display-name" normal>
 					{beacon?.computedName || `${beacon.server?.computedName}`}
 				</Txt>
-				<Txt cy-test="beacon-user">{beacon.meta?.[0]?.maybeCurrent?.username}</Txt>
 			</RowTitle>
 			<FlexSplitter />
 			{beacon?.hidden && <IconLabel cy-test="hidden" title="Hidden" icon={ViewOff16} />}


### PR DESCRIPTION
1 line fix to remove the duplicate beacon name in BeaconRow.