### PR TITLE
Bug Fix - beacon name was missing from SearchRows

### DIFF
--- a/applications/client/src/views/Campaign/Search/util.tsx
+++ b/applications/client/src/views/Campaign/Search/util.tsx
@@ -23,7 +23,7 @@ export const getPaths = (store: AppStore, { server, host, beacon }: any): (strin
 		return [
 			store.graphqlStore.servers.get(server)?.computedName,
 			store.graphqlStore.hosts.get(host)?.computedName,
-			store.graphqlStore.hosts.get(beacon)?.computedName,
+			store.graphqlStore.beacons.get(beacon)?.computedName,
 		];
 	}
 	if (host)


### PR DESCRIPTION
## Changes
- fix bug chaining incorrect property in `getPath`

## Screenshots

![Screen Shot 2023-09-19 at 4 01 13 PM](https://github.com/cisagov/RedEye/assets/6248614/86e5a34f-8f95-4b80-ae38-b50d2252c212)
![Screen Shot 2023-09-19 at 4 02 24 PM](https://github.com/cisagov/RedEye/assets/6248614/b7bd7af8-4efc-4429-9efa-3eddef950a9a)
